### PR TITLE
Add usleep alternative for Windows (Fixes #3)

### DIFF
--- a/player.cpp
+++ b/player.cpp
@@ -7,6 +7,11 @@
 #include <unistd.h>
 #include "data_header.h"
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+#include <thread>
+#define usleep(t) std::this_thread::sleep_for(std::chrono::microseconds(t));
+#endif
+
 using namespace std::chrono;
 
 struct term_size_t {

--- a/player.cpp
+++ b/player.cpp
@@ -3,14 +3,10 @@
 #include <csignal>
 #include <cstring>
 #include <chrono>
+#include <thread>
 #include <assert.h>
 #include <unistd.h>
 #include "data_header.h"
-
-#if defined(_WIN32) || defined(__CYGWIN__)
-#include <thread>
-#define usleep(t) std::this_thread::sleep_for(std::chrono::microseconds(t));
-#endif
 
 using namespace std::chrono;
 
@@ -156,7 +152,7 @@ int main()
 			// but I don't actually want to sleep by an entire frame's duration
 			// I just want to sleep enough so the loop isn't constantly getting slammed
 			// while hopefully not actually stalling the framerate performance
-			usleep(100000u/header.framerate);
+			std::this_thread::sleep_for(microseconds(100000u/header.framerate));
 		}
 	}
 


### PR DESCRIPTION
I personally use Cygwin, which doesn't define `_WIN32`. There may be other "GNU-like system" abstractions on Windows, but this works in the two most common ones I know of (MinGW and Cygwin).